### PR TITLE
리펙토링: AuditingFields 클래스를 추상 클래스로 변경

### DIFF
--- a/src/main/java/com/project/board/domain/AuditingFields.java
+++ b/src/main/java/com/project/board/domain/AuditingFields.java
@@ -1,0 +1,41 @@
+package com.project.board.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt; // 생성일시
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    protected String createdBy; // 생성자
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt; // 수정일시
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    protected String modifiedBy; // 수정자
+
+}


### PR DESCRIPTION
엔티티에서 상속으로 사용해야 하는 목적에 더 맞게 `abstract` 키워드 추가

this closes #20